### PR TITLE
Revert "Fixed typo in 3.md"

### DIFF
--- a/content/en/exercises/intro/3.md
+++ b/content/en/exercises/intro/3.md
@@ -21,7 +21,7 @@ answer: |
 
 Awesome! We’ve filtered our data to only show trees!
 
-If you notice on the text editor on the right, [natural=tree] is placed on the 2nd line. Overpass Turbo allows you to add indentation and extra lines as you see fit, so feel free to make sample use of them to make your queries more readable! Note however, that the semicolon is also placed in the second line to tell Overpass that statement is finished. Think of it as Overpass’ period.
+If you notice on the text editor on the right, [natural=tree] is placed on the 2nd line. Overpass Turbo allows you to add indentation and extra lines as you see fit, so feel free to make ample use of them to make your queries more readable! Note however, that the semicolon is also placed in the second line to tell Overpass that statement is finished. Think of it as Overpass’ period.
 
 Anyway, we successfully filtered the data to only request for trees. However, we still have a problem. While “Bob” told us he is at a tree, there are THREE trees in the area!
 


### PR DESCRIPTION
Reverts osmlab/learnoverpass#14

see https://github.com/osmlab/learnoverpass/commit/70c692401f00968c3fb649639e448613054ad2a7#commitcomment-14110464