### PR TITLE
Don't mix content, request all resources by HTTPS

### DIFF
--- a/themes/src/layouts/exercise/single.html
+++ b/themes/src/layouts/exercise/single.html
@@ -60,7 +60,7 @@
        </div>
      </div>
      <div class="docs-repl-result output">
-       <iframe src="http://overpass-turbo.eu/master/map.html?silent" seamless="seamless" frameBorder="0">
+       <iframe src="https://overpass-turbo.eu/master/map.html?silent" seamless="seamless" frameBorder="0">
        </iframe>
        <textarea></textarea>
        <a class="docs-repl-change-output button" href="#">Data</a>

--- a/themes/src/layouts/partials/head.html
+++ b/themes/src/layouts/partials/head.html
@@ -18,7 +18,7 @@
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
   <link href="/favicon.png" rel="icon">
-  <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
 
   <!--[if lt IE 9]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.5/es5-shim.min.js"></script>

--- a/themes/src/layouts/shortcodes/docs_repl.html
+++ b/themes/src/layouts/shortcodes/docs_repl.html
@@ -6,9 +6,9 @@
 
   <div class="docs-repl-result">
     {{ if eq "=" (substr .Inner 0 1) }}
-    <iframe src="http://overpass-turbo.eu/master/map.html?silent"
+    <iframe src="https://overpass-turbo.eu/master/map.html?silent"
     {{ else }}
-    <iframe src="http://overpass-turbo.eu/master/map.html?silent&Q={{ .Inner }}"
+    <iframe src="https://overpass-turbo.eu/master/map.html?silent&Q={{ .Inner }}"
     {{ end }}
           seamless="seamless"
           frameBorder="0" 


### PR DESCRIPTION
Modern browsers block _insecure_ content, in our case that was map iframe and Roboto font sourced over http://.

This change would allow loading LearnOverpass over https://.