### PR TITLE
Don't use explicit HTML escaping

### DIFF
--- a/themes/src/layouts/exercise/single.html
+++ b/themes/src/layouts/exercise/single.html
@@ -66,8 +66,8 @@
        <a class="docs-repl-change-output button" href="#">Data</a>
      </div>
    </div>
-   <div class="exercise-answer">{{ .Params.answer | html }}</div>
-   <div class="exercise-regex">{{ .Params.regex | html }}</div>
+   <div class="exercise-answer">{{ .Params.answer }}</div>
+   <div class="exercise-regex">{{ .Params.regex }}</div>
 </div>
 {{ partial "shared.js.html" . }}
 {{ partial "exercise.js.html" . }}


### PR DESCRIPTION
This fixes issue #25.

Given that html/template package used by Hugo has contextual autoescaping, explicit HTML escaping is not needed, so changing {{ .Params.regex | html }} to {{ .Params.regex }} will effectively fix the issue and would not introduce an HTML injection.